### PR TITLE
Styling tweaks for list readability and responsive calendar embeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,7 @@ ENV/
 
 node_modules
 .coverage_js
+
+# other IDE/tooling
+.idea/
+.tool-versions

--- a/app/templates/chase_center.htm
+++ b/app/templates/chase_center.htm
@@ -8,9 +8,9 @@
     <h1>Chase Center Calendar</h1>
     <div id="events">
       {% for event in events %}
-        <div id="event">
-          <h2>{{ event.title }}</h1>
-          <h3>{{ event.date.strftime('%A %Y-%m-%d') }} {{ event.date.strftime('%I:%M %p') }} - {{ event.end.strftime('%I:%M %p') }}</h2>
+        <div class="event">
+          <h2>{{ event.title }}</h2>
+          <h3>{{ event.date.strftime('%A %Y-%m-%d') }} {{ event.date.strftime('%I:%M %p') }} - {{ event.end.strftime('%I:%M %p') }}</h3>
           {% if event.subtitle %}
             Subtitle: {{ event.subtitle }}<br />
           {% endif %}

--- a/app/templates/index.htm
+++ b/app/templates/index.htm
@@ -6,8 +6,12 @@
 {% block content %}
   <div>
     <h1>Chase Center Calendar</h1>
-    <iframe src="https://calendar.google.com/calendar/u/0/embed?height=600&wkst=1&ctz=America/Los_Angeles&mode=AGENDA&title=Chase+Center+Calendar&showCalendars=0&src=aTVuYzU1ZGNxZnBuc3B0dWVqMG5jbGRvNGpnb3RxdTBAaW1wb3J0LmNhbGVuZGFyLmdvb2dsZS5jb20&color=%23F4511E" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+    <div class="embed-calendar">
+      <iframe src="https://calendar.google.com/calendar/u/0/embed?height=600&wkst=1&ctz=America/Los_Angeles&mode=AGENDA&title=Chase+Center+Calendar&showCalendars=0&src=aTVuYzU1ZGNxZnBuc3B0dWVqMG5jbGRvNGpnb3RxdTBAaW1wb3J0LmNhbGVuZGFyLmdvb2dsZS5jb20&color=%23F4511E" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+    </div>
     <h1>Oracle Park Calendar</h1>
-    <iframe src="https://calendar.google.com/calendar/u/0/embed?height=600&wkst=1&ctz=America/Los_Angeles&mode=AGENDA&title=Oracle+Park+Calendar&showCalendars=0&src=bDg3Y25wN2QyYzhwcjk1amE5MWo5a25jZzMxNDQyM3NAaW1wb3J0LmNhbGVuZGFyLmdvb2dsZS5jb20&color=%23F4511E" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+    <div class="embed-calendar">
+      <iframe src="https://calendar.google.com/calendar/u/0/embed?height=600&wkst=1&ctz=America/Los_Angeles&mode=AGENDA&title=Oracle+Park+Calendar&showCalendars=0&src=bDg3Y25wN2QyYzhwcjk1amE5MWo5a25jZzMxNDQyM3NAaW1wb3J0LmNhbGVuZGFyLmdvb2dsZS5jb20&color=%23F4511E" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+    </div>
   </div>
 {% endblock %}

--- a/app/templates/oracle_park.htm
+++ b/app/templates/oracle_park.htm
@@ -11,9 +11,9 @@
     #}
     <div id="events">
       {% for event in events %}
-        <div id="event">
-          <h2>{{ event.title }}</h1>
-          <h3>{{ event.date.strftime('%A %Y-%m-%d') }} {{ event.date.strftime('%I:%M %p') }} - {{ event.end.strftime('%I:%M %p') }}</h2>
+        <div class="event">
+          <h2>{{ event.title }}</h2>
+          <h3>{{ event.date.strftime('%A %Y-%m-%d') }} {{ event.date.strftime('%I:%M %p') }} - {{ event.end.strftime('%I:%M %p') }}</h3>
           {% if event.subtitle %}
             Subtitle: {{ event.subtitle }}<br />
           {% endif %}

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -11,6 +11,10 @@ body {
     margin-bottom: 150px;
 }
 
+h1 {
+    margin-top: 8px;
+}
+
 img {
     max-width: 100%;
     height: auto;
@@ -25,4 +29,33 @@ img {
 
 #logos img {
     width: 25%;
+}
+
+.embed-calendar {
+    position: relative;
+    padding-bottom: 75%;
+    height: 0;
+    overflow: hidden;
+
+    iframe {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
+}
+
+.event {
+    padding: 12px;
+    margin-bottom: 8px;
+
+    &:nth-child(odd) {
+        background-color: #f8f9fa;
+    }
+
+    &:nth-child(even) {
+        background-color: white;
+    }
+
 }


### PR DESCRIPTION
- css around the embedded calendars to nudge them into being responsive, looks ok on phone/tablet/monitor
- very light css zebra effect on alternating list rows, aids the eye focus on each item
- css to open up a little room above h1, give breathing room in the layouts
- change id=event to class both to avoid duplicate ids and to target the zebra effect
- small typo fixes to h2 & h3 closing tags
- adding a couple more IDE and version manager bits to gitignore