### PR TITLE
Handle incorrect "location" field in Chase Center games

### DIFF
--- a/app/chasecenter.py
+++ b/app/chasecenter.py
@@ -59,8 +59,10 @@ def initialize_chase_event(data: RawEvent) -> Event:
     date = datetime.datetime.fromisoformat(event.date_string)
     event.date = date.astimezone(tz=TIMEZONE)
     event.location_name = cast(Optional[str], data['location'])
-    if event.location_name == 'home':
+    if event.location_name == 'home' and data['home']:
         event.location_name = 'Chase Center, San Francisco'
+    elif event.location_name == 'home':
+        event.location_name = f'{data["arena"]}, {data["city"]} {data["state"]}'
     event.duration = 3
     return event
 


### PR DESCRIPTION
Currently Valkyrie & Warrior away games are being shown on the calendar, with the location set to "Chase Center, San Francisco". You can grep for `Valkyries at` or `Warriors at` in the ICS to see examples.

It looks like the API returns `location: home` even for away games, but the `home` boolean field is still accurate (but shouldn't be consulted for non-NBA/WNBA games). This PR fixes the detection of the location and creates a correct location for the away games.

But instead you may prefer to just filter them out (that would be more useful for a Chase Center calendar after all). I didn't know where you'd prefer the filtering logic so I just wanted to at least illustrate the issue and one way to detect it.

thanks!